### PR TITLE
When checking if any batteries are discharging, check for their presence too

### DIFF
--- a/AppleSmartBatteryManager/BatteryTracker.cpp
+++ b/AppleSmartBatteryManager/BatteryTracker.cpp
@@ -136,7 +136,7 @@ bool BatteryTracker::anyBatteriesDischarging(AppleSmartBattery* pExcept)
     for (unsigned i = 0; i < count; ++i)
     {
         AppleSmartBatteryManager* pManager = static_cast<AppleSmartBatteryManager*>(m_pBatteryList->getObject(i));
-        if (pManager && pManager->fBattery && pExcept != pManager->fBattery && !pManager->fBattery->fACConnected)
+        if (pManager && pManager->fBattery && pExcept != pManager->fBattery && pManager->fBattery->fBatteryPresent && !pManager->fBattery->fACConnected)
         {
             result = true;
             break;


### PR DESCRIPTION
When a battery is not present, due to the fact that we always set fACConnected
for it to true to enable boot without batteries, the tracker cannot rely on
the fACConnected flag alone.

Thus, check also that the battery is marked as present.
