### PR TITLE
Fixed the power source (un)plug delay observed on XPS15 9550

### DIFF
--- a/ACPIBatteryManager.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ACPIBatteryManager.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/AppleSmartBatteryManager/ACAdapter.cpp
+++ b/AppleSmartBatteryManager/ACAdapter.cpp
@@ -71,6 +71,7 @@ IOReturn ACPIACAdapter::message(UInt32 type, IOService* provider, void* argument
     if (type == kIOACPIMessageDeviceNotification && fProvider)
     {
         UInt32 acpi = 0;
+		fProvider->evaluateInteger("_PSR", &acpi);
         if (kIOReturnSuccess == fProvider->evaluateInteger("_PSR", &acpi))
         {
             DebugLog("ACPIACAdapter::message setting AC %s\n", (acpi ? "connected" : "disconnected"));

--- a/AppleSmartBatteryManager/AppleSmartBattery.cpp
+++ b/AppleSmartBatteryManager/AppleSmartBattery.cpp
@@ -92,8 +92,8 @@ enum
 
 static uint32_t milliSecPollingTable[2] =
 { 
-	30000,    // 0 == Regular 30 second polling
-	1000      // 1 == Quick 1 second polling
+	60000,    // 0 == Regular 30 second polling
+	60000      // 1 == Quick 1 second polling
 };
 
 // Keys we use to publish battery state in our IOPMPowerSource::properties array


### PR DESCRIPTION
My laptop is Precision 5510 (XPS15) and has had the problem of the OS taking forever (it can take as long as 30 seconds) to respond to the (un)plugging from/to the power source. It turned out that the `_PSR` method failed due to unknown reasons. The fix was found by sheer serendipity and is as simple as calling `evaluateInteger()` twice. I'm not sure why that fixed the issue but it seems working not just on my machine but other XPS 15 9550s as well. 

The changes of `milliSecPollingTable[2]` are made due to the fact that this kext seems to affect `VoodooI2C` quite a bit with its quick 1 second polling. The cursor burps every one second or so, and I've traced the root of the issue to the `evaluateObject()` in `AppleSmartBatteryManager::getBatteryBIF()`. I set it to 60 seconds so it's much less noticeable.